### PR TITLE
Add support for project-specific PHP CS Fixer and Rector configs

### DIFF
--- a/internal/tool/phpcsfixer.go
+++ b/internal/tool/phpcsfixer.go
@@ -19,6 +19,14 @@ func (p PHPCSFixer) Fix(ctx context.Context, config ToolConfig) error {
 	return nil
 }
 
+func (p PHPCSFixer) getConfigPath(cwd, rootDir string) string {
+	if _, err := os.Stat(path.Join(rootDir, ".php-cs-fixer.dist.php")); err == nil {
+		return path.Join(rootDir, ".php-cs-fixer.dist.php")
+	}
+
+	return path.Join(cwd, "tools", "php", ".php-cs-fixer.dist.php")
+}
+
 func (p PHPCSFixer) Format(ctx context.Context, config ToolConfig, dryRun bool) error {
 	// Apps don't have an composer.json file, skip them
 	if _, err := os.Stat(path.Join(config.RootDir, "composer.json")); err != nil {
@@ -40,7 +48,7 @@ func (p PHPCSFixer) Format(ctx context.Context, config ToolConfig, dryRun bool) 
 			fixDir = path.Join(cwd, fixDir)
 		}
 
-		args := []string{"fix", "--config", path.Join(cwd, "tools", "php", ".php-cs-fixer.dist.php"), fixDir}
+		args := []string{"fix", "--config", p.getConfigPath(cwd, config.RootDir), fixDir}
 		if dryRun {
 			args = append(args, "--dry-run")
 		}

--- a/internal/tool/rector.go
+++ b/internal/tool/rector.go
@@ -50,7 +50,13 @@ func (r Rector) Fix(ctx context.Context, config ToolConfig) error {
 		}
 	}
 
-	rectorConfigFile := path.Join(cwd, "tools", "php", "vendor", "frosh", "shopware-rector", "config", fmt.Sprintf("shopware-%s.0.php", config.MinShopwareVersion[0:3]))
+	var rectorConfigFile string
+
+	if _, err := os.Stat(path.Join(config.RootDir, "rector.php")); err == nil {
+		rectorConfigFile = path.Join(config.RootDir, "rector.php")
+	} else {
+		rectorConfigFile = path.Join(cwd, "tools", "php", "vendor", "frosh", "shopware-rector", "config", fmt.Sprintf("shopware-%s.0.php", config.MinShopwareVersion[0:3]))
+	}
 
 	if err := installComposerDeps(config.RootDir, "highest"); err != nil {
 		return err


### PR DESCRIPTION
This PR adds support for project-specific configuration files for PHP CS Fixer and Rector.

### Changes

- Added support for `.php-cs-fixer.dist.php` in project root
  - The tool will now first check for a project-specific config file
  - Falls back to the default config if no project-specific config is found

- Added support for `rector.php` in project root
  - The tool will now first check for a project-specific Rector config
  - Falls back to the default Shopware version-specific config if no project config is found

### Why

This change allows extension developers to use their own PHP CS Fixer and Rector configurations while still maintaining compatibility with the default configurations when no custom configs are present.

### Technical Details

- Added `getConfigPath` method to PHPCSFixer to handle config file resolution
- Modified Rector config file resolution to check for project-specific config first
- Maintained backward compatibility by falling back to default configs