### PR TITLE
fix: improve identifier ignore behavior

### DIFF
--- a/internal/tool/result.go
+++ b/internal/tool/result.go
@@ -40,12 +40,24 @@ func (c *Check) RemoveByIdentifier(ignores []ToolConfigIgnore) *Check {
 	for _, r := range c.Results {
 		shouldKeep := true
 		for _, ignore := range ignores {
-			if ignore.Identifier != "" && r.Identifier == ignore.Identifier && (r.Path == ignore.Path || ignore.Path == "") {
-				shouldKeep = false
-				break
+			// Only ignore all matches when identifier is the only field specified
+			if ignore.Identifier != "" && ignore.Path == "" && ignore.Message == "" {
+				if r.Identifier == ignore.Identifier {
+					shouldKeep = false
+					break
+				}
 			}
 
-			if ignore.Message != "" && strings.Contains(r.Message, ignore.Message) && (r.Path == ignore.Path || ignore.Path == "") {
+			// If path is specified with identifier (but no message), match both
+			if ignore.Identifier != "" && ignore.Path != "" && ignore.Message == "" {
+				if r.Identifier == ignore.Identifier && r.Path == ignore.Path {
+					shouldKeep = false
+					break
+				}
+			}
+
+			// Handle message-based ignores (when no identifier is specified)
+			if ignore.Identifier == "" && ignore.Message != "" && strings.Contains(r.Message, ignore.Message) && (r.Path == ignore.Path || ignore.Path == "") {
 				shouldKeep = false
 				break
 			}


### PR DESCRIPTION
This PR improves the behavior of the identifier-based ignore functionality:

- Only ignore all matches when identifier is the only field specified
- Handle identifier+path matches correctly (only remove errors in specified file)
- Do not remove errors when both identifier and message are specified
- Keep existing message-based ignore behavior unchanged

The changes make the ignore behavior more predictable and consistent with the test expectations.