### PR TITLE
feat(stylelint): avoid direct element selectors

### DIFF
--- a/tools/js/stylelint.config.storefront.mjs
+++ b/tools/js/stylelint.config.storefront.mjs
@@ -16,6 +16,9 @@ export default {
         "max-nesting-depth": [3, {
             "ignore": ["blockless-at-rules", "pseudo-classes"],
             "severity": "warning"
-        }]
+        }],
+        "selector-max-type": [0, {
+            "message": "Selectors containing elements like \"%s\" should be avoided because the element type might change. Prefer to use .classes, #ids and [data-attributes] instead."
+        }],
     }
 };


### PR DESCRIPTION
Adds a stylelint rule to avoid selectors depending on HTML elements like `a {}` or `div.custom-class {}` because semantic changes could break the CSS later.

[stylelint demo example](https://stylelint.io/demo/#N4Igxg9gJgpiBcIoEsBuA6MBXAzgFwgFsBaMAGwEMccACYAHQDt69IyIAneGjmKAbiYBfJk0y4CJclVoNmrCOy48+gxiOaMKAYmz4ixZFDqiFS7gCMyWGGo1NdEg0ZPy2nS9dvDRWgNpQFHgUpE4kQXgcALquLO7KAJ4wZOwA7na+AUEhepLEEdGxZh40SSkQ6T6MIAA0IABmyGQwAHIUhHCIMAAe7QAOzZjUteAQjI0A5gggcjQ09CA9eDCMUDgL3H5Mc3ML+AnNZMiMeKRjk8T4FKsUHFAL2zRRNY8LHFjN6wiuO-MgOMkYGACBxiIQKN1iHgEn0YBsaH4AAw1H6-P4dagUCZw74LADKgOBnFokBOFGOxwmNEBHROtCOAGsYPN6AsAKTrVkgGg4AAWEA+xgszIoqAgRj4NGFYAouGZeF5zJpKzwNGhsJohGQE15qrAvOu2PQNAACrx6jAOGqIDQ5TRMJRqDAcCjtEZaNdjFlgvk8JFkBYsMscDFjvgYBQoOgHoxfkIoo8NEIRqTJgAxTjgvDTABWODGI1gfRw01mf32h2OeHhC0owertVe-2hlZOZ3G2suwRudxrIDrzobwhAQiAA)

![image](https://github.com/user-attachments/assets/28ae9e11-8dd9-45e4-ae56-5c50bbe6d4b4)
