### PR TITLE
feat: add --only flag to run specific tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ The check command has multiple reporting options, you can use `--reporter` to sp
 - `github` - GitHub Actions output
 - `markdown` - markdown output
 
+## Running Specific Tools
+
+Instead of running all tools, you can choose to run specific tools using the `--only` flag. The following tools are available:
+
+- `phpstan` - PHP static analysis
+- `sw-cli` - Shopware CLI validation checks
+- `stylelint` - CSS/SCSS linting
+- `twig` - Twig template checks
+- `admin-twig` - Admin Twig template checks
+- `php-cs-fixer` - PHP code style fixing
+- `prettier` - Code formatting
+- `eslint` - JavaScript/TypeScript linting
+- `rector` - PHP code refactoring
+
+You can run a single tool:
+
+```shell
+docker run --rm -v $(pwd):/ext ghcr.io/shopwarelabs/extension-verifier:latest check /ext --only phpstan
+```
+
+Or run multiple tools by separating them with commas:
+
+```shell
+docker run --rm -v $(pwd):/ext ghcr.io/shopwarelabs/extension-verifier:latest check /ext --only "phpstan,eslint,stylelint"
+```
+
+This is particularly useful when:
+- You want to focus on specific aspects of your code
+- You want to run only the relevant tools for the files you've changed
+- You want to fix issues one tool at a time
+
 ## Refactoring
 
 To run the refactoring, you can use following command:
@@ -141,8 +172,6 @@ The fixers are enabled by the supported Shopware Version by the constraint in th
 ### Missing classes in Storefront/Elasticsearch bundle
 
 Your plugin typically requires only `shopware/core`, but when you use classes from Storefront or Elasticsearch Bundle and they are required, you have to add `shopware/storefront` or `shopware/elasticsearch` also to the `require` in the composer.json. If those features are optional with `class_exists` checks, you want to add them into `require-dev`, so the dependencies are installed only for development, and PHPStan can recognize the files.
-
-
 
 # Contribution
 

--- a/cmd_check.go
+++ b/cmd_check.go
@@ -86,7 +86,15 @@ var checkCommand = &cobra.Command{
 
 		var gr errgroup.Group
 
-		for _, tool := range tool.GetTools() {
+		tools := tool.GetTools()
+		only, _ := cmd.Flags().GetString("only")
+
+		tools, err = filterTools(tools, only)
+		if err != nil {
+			return err
+		}
+
+		for _, tool := range tools {
 			tool := tool
 			gr.Go(func() error {
 				return tool.Check(cmd.Context(), result, *toolCfg)
@@ -105,6 +113,7 @@ func init() {
 	rootCmd.AddCommand(checkCommand)
 	checkCommand.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, junit, markdown)")
 	checkCommand.PersistentFlags().String("check-against", "highest", "Check against Shopware Version (highest, lowest)")
+	checkCommand.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	checkCommand.PreRunE = func(cmd *cobra.Command, args []string) error {
 		reporter, _ := cmd.Flags().GetString("reporter")
 		if reporter != "summary" && reporter != "json" && reporter != "github" && reporter != "junit" && reporter != "markdown" && reporter != "" {

--- a/cmd_fix.go
+++ b/cmd_fix.go
@@ -39,7 +39,16 @@ var (
 
 			var gr errgroup.Group
 
-			for _, tool := range tool.GetTools() {
+			tools := tool.GetTools()
+			only, _ := cmd.Flags().GetString("only")
+
+			tools, err = filterTools(tools, only)
+			if err != nil {
+				return err
+			}
+
+			for _, tool := range tools {
+				tool := tool
 				gr.Go(func() error {
 					return tool.Fix(cmd.Context(), *toolCfg)
 				})
@@ -56,5 +65,6 @@ var (
 
 func init() {
 	fixCommand.Flags().BoolVar(&allowNonGit, "allow-non-git", false, "Allow running the fix command on non-git repositories")
+	fixCommand.Flags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	rootCmd.AddCommand(fixCommand)
 }

--- a/cmd_format.go
+++ b/cmd_format.go
@@ -28,7 +28,16 @@ var formatCommand = &cobra.Command{
 
 		var gr errgroup.Group
 
-		for _, tool := range tool.GetTools() {
+		tools := tool.GetTools()
+		only, _ := cmd.Flags().GetString("only")
+
+		tools, err = filterTools(tools, only)
+		if err != nil {
+			return err
+		}
+
+		for _, tool := range tools {
+			tool := tool
 			gr.Go(func() error {
 				return tool.Format(cmd.Context(), *toolCfg, dryRun)
 			})
@@ -45,4 +54,5 @@ var formatCommand = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(formatCommand)
 	formatCommand.PersistentFlags().Bool("dry-run", false, "Dry run the formatting")
+	formatCommand.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
 }

--- a/cmd_shared.go
+++ b/cmd_shared.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopware/extension-verifier/internal/tool"
+)
+
+func filterTools(tools []tool.Tool, only string) ([]tool.Tool, error) {
+	if only == "" {
+		return tools, nil
+	}
+
+	var filteredTools []tool.Tool
+	requestedTools := strings.Split(only, ",")
+
+	for _, requestedTool := range requestedTools {
+		requestedTool = strings.TrimSpace(requestedTool)
+		found := false
+
+		for _, t := range tools {
+			if t.Name() == requestedTool {
+				filteredTools = append(filteredTools, t)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("tool with name %q not found", requestedTool)
+		}
+	}
+
+	return filteredTools, nil
+}

--- a/internal/tool/admin_twig.go
+++ b/internal/tool/admin_twig.go
@@ -17,6 +17,10 @@ import (
 
 type AdminTwigLinter struct{}
 
+func (a AdminTwigLinter) Name() string {
+	return "admin-twig"
+}
+
 func (a AdminTwigLinter) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	fixers := admintwiglinter.GetFixers(version.Must(version.NewVersion(config.MinShopwareVersion)))
 

--- a/internal/tool/eslint.go
+++ b/internal/tool/eslint.go
@@ -41,6 +41,10 @@ type EslintOutput []struct {
 
 type Eslint struct{}
 
+func (e Eslint) Name() string {
+	return "eslint"
+}
+
 func (e Eslint) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	cwd, err := os.Getwd()
 

--- a/internal/tool/phpcsfixer.go
+++ b/internal/tool/phpcsfixer.go
@@ -11,6 +11,10 @@ import (
 
 type PHPCSFixer struct{}
 
+func (p PHPCSFixer) Name() string {
+	return "php-cs-fixer"
+}
+
 func (p PHPCSFixer) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	return nil
 }

--- a/internal/tool/phpstan.go
+++ b/internal/tool/phpstan.go
@@ -39,6 +39,10 @@ type PhpStanOutput struct {
 
 type PhpStan struct{}
 
+func (p PhpStan) Name() string {
+	return "phpstan"
+}
+
 func (p PhpStan) configExists(pluginPath string) bool {
 	for _, config := range possiblePHPStanConfigs {
 		if _, err := os.Stat(path.Join(pluginPath, config)); err == nil {

--- a/internal/tool/prettier.go
+++ b/internal/tool/prettier.go
@@ -18,6 +18,10 @@ Resources/store/**
 
 type Prettier struct{}
 
+func (b Prettier) Name() string {
+	return "prettier"
+}
+
 func (b Prettier) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	return nil
 }

--- a/internal/tool/rector.go
+++ b/internal/tool/rector.go
@@ -10,6 +10,10 @@ import (
 
 type Rector struct{}
 
+func (r Rector) Name() string {
+	return "rector"
+}
+
 func (r Rector) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	return nil
 }

--- a/internal/tool/stylelint.go
+++ b/internal/tool/stylelint.go
@@ -32,6 +32,10 @@ type StylelintOutput []struct {
 
 type StyleLint struct{}
 
+func (s StyleLint) Name() string {
+	return "stylelint"
+}
+
 func (s StyleLint) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/tool/sw_cli.go
+++ b/internal/tool/sw_cli.go
@@ -8,6 +8,10 @@ import (
 
 type SWCLI struct{}
 
+func (s SWCLI) Name() string {
+	return "sw-cli"
+}
+
 func (s SWCLI) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	if config.Extension == nil {
 		return nil

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -44,6 +44,7 @@ type ToolConfigIgnore struct {
 }
 
 type Tool interface {
+	Name() string
 	Check(ctx context.Context, check *Check, config ToolConfig) error
 	Fix(ctx context.Context, config ToolConfig) error
 	Format(ctx context.Context, config ToolConfig, dryRun bool) error

--- a/internal/tool/twig.go
+++ b/internal/tool/twig.go
@@ -18,6 +18,10 @@ import (
 
 type Twig struct{}
 
+func (t Twig) Name() string {
+	return "twig"
+}
+
 func (t Twig) Check(ctx context.Context, check *Check, config ToolConfig) error {
 	return nil
 }


### PR DESCRIPTION
Added the ability to run specific tools using the `--only` flag to all commands (check, fix, format). The flag accepts comma-separated tool names to run multiple tools.

### Features
- Added `--only` flag to `check`, `fix`, and `format` commands
- Created shared tool filtering logic in `cmd_shared.go`
- Updated README with documentation about the new feature
- Added proper error handling for non-existent tool names

### Example Usage
```bash
# Run a single tool
extension-verifier check [path] --only phpstan

# Run multiple tools
extension-verifier check [path] --only "phpstan,eslint,stylelint"
```

### Available Tools
- `phpstan` - PHP static analysis
- `sw-cli` - Shopware CLI validation checks
- `stylelint` - CSS/SCSS linting
- `twig` - Twig template checks
- `admin-twig` - Admin Twig template checks
- `php-cs-fixer` - PHP code style fixing
- `prettier` - Code formatting
- `eslint` - JavaScript/TypeScript linting
- `rector` - PHP code refactoring