### PR TITLE
fix: Replace v-model:value attributes for switch field

### DIFF
--- a/internal/admintwiglinter/fix_switch.go
+++ b/internal/admintwiglinter/fix_switch.go
@@ -48,6 +48,9 @@ func (s SwitchFixer) Fix(nodes []html.Node) error {
 						// remove these attributes
 					case "value":
 						newAttrs = append(newAttrs, html.Attribute{Key: "checked", Value: attr.Value})
+					case "v-model:value":
+						attr.Key = "v-model"
+						newAttrs = append(newAttrs, attr)
 					default:
 						newAttrs = append(newAttrs, attr)
 					}

--- a/internal/admintwiglinter/fix_switch_test.go
+++ b/internal/admintwiglinter/fix_switch_test.go
@@ -18,6 +18,11 @@ func TestSwitchFixer(t *testing.T) {
 			after:       `<mt-switch>Hello World</mt-switch>`,
 		},
 		{
+			description: "replace v-model:value",
+			before:      `<sw-switch-field v-model:value="foobar">Hello World</sw-switch-field>`,
+			after:       `<mt-switch v-model="foobar">Hello World</mt-switch>`,
+		},
+		{
 			description: "replace noMarginTop with removeTopMargin",
 			before:      `<sw-switch-field noMarginTop />`,
 			after:       `<mt-switch removeTopMargin/>`,


### PR DESCRIPTION
In general I am not sure if it should be `v-model:checked` or `v-model`:
https://github.com/shopware/meteor/blob/main/packages/component-library/src/components/form/mt-switch/mt-switch.vue#L24

But I tested it, and for me it only works with `v-model`.