### PR TITLE
refactor: Replace v-model:value by v-model for the number field

### DIFF
--- a/internal/admintwiglinter/fix_number_field.go
+++ b/internal/admintwiglinter/fix_number_field.go
@@ -48,14 +48,8 @@ func (n NumberFieldFixer) Fix(nodes []html.Node) error {
 							Value: attr.Value,
 						})
 					case "v-model:value":
-						newAttrs = append(newAttrs, html.Attribute{
-							Key:   ":model-value",
-							Value: attr.Value,
-						})
-						newAttrs = append(newAttrs, html.Attribute{
-							Key:   "@change",
-							Value: attr.Value + " = $event",
-						})
+						attr.Key = "v-model"
+						newAttrs = append(newAttrs, attr)
 					case "@update:value":
 						newAttrs = append(newAttrs, html.Attribute{
 							Key:   "@change",

--- a/internal/admintwiglinter/fix_number_field_test.go
+++ b/internal/admintwiglinter/fix_number_field_test.go
@@ -25,10 +25,7 @@ func TestNumberFieldFixer(t *testing.T) {
 		{
 			description: "convert v-model:value to :model-value and @change",
 			before:      `<sw-number-field v-model:value="myValue"/>`,
-			after: `<mt-number-field
-    :model-value="myValue"
-    @change="myValue = $event"
-/>`,
+			after:       `<mt-number-field v-model="myValue"/>`,
 		},
 		{
 			description: "convert label slot to label prop",


### PR DESCRIPTION
This is currently the "long" form, which works, but is probably not needed, and not consistent with the other fields: https://vuejs.org/guide/components/v-model.html