### PR TITLE
Update .php-cs-fixer.dist.php to only parse PHP files

### DIFF
--- a/tools/php/.php-cs-fixer.dist.php
+++ b/tools/php/.php-cs-fixer.dist.php
@@ -49,6 +49,7 @@ return (new PhpCsFixer\Config())
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
+        ->name('/\.php$/')
         ->in(__DIR__),
     )
 ;


### PR DESCRIPTION
Resolves https://github.com/shopwareLabs/extension-verifier/issues/37

This pull request includes a small change to the `tools/php/.php-cs-fixer.dist.php` file. The change adds a new rule to include only files with the `.php` extension in the PHP-CS-Fixer configuration.

* [`tools/php/.php-cs-fixer.dist.php`](diffhunk://#diff-6f9f32f4240e169c13da43b8424e46f396697c914e643bff428eac516be08758R52): Added a rule to include only files with the `.php` extension in the finder configuration.