### PR TITLE
feat: add version command to show CLI version information

### DIFF
--- a/cmd_version.go
+++ b/cmd_version.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+func init() {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("extension-verifier version %s\n", version)
+			fmt.Printf("  Go version: %s\n", runtime.Version())
+			fmt.Printf("  OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		},
+	}
+
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
This PR adds a new `version` command to the CLI tool that displays:

- The extension-verifier version
- The Go runtime version
- The OS and architecture information

Example usage:
```bash
sw-extension-verifier version
```

Example output:
```
extension-verifier version dev
  Go version: go1.24.0
  OS/Arch: darwin/arm64
```

The version information can be set during build time using ldflags:
```bash
go build -ldflags="-X main.version=1.0.0"
```