### PR TITLE
Fix cmd_fix to check if the provided path is a project

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,6 +23,9 @@ jobs:
         run: |
           echo "REPO_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -38,6 +41,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ steps.repo-name.outputs.REPO_NAME }}/pr-${{ github.event.pull_request.number }}:latest
       
       - name: Comment on PR

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,109 @@
+name: PR Docker Image Workflow
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  # Build and push Docker image, then comment on PR
+  build-and-comment:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Lowercase repository name
+        id: repo-name
+        run: |
+          echo "REPO_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ steps.repo-name.outputs.REPO_NAME }}/pr-${{ github.event.pull_request.number }}:latest
+      
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const imageName = `ghcr.io/${{ steps.repo-name.outputs.REPO_NAME }}/pr-${context.issue.number}:latest`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📦 Docker image for this PR is available at: \`${imageName}\`
+            
+            You can pull it with:
+            \`\`\`
+            docker pull ${imageName}
+            docker run ${imageName}
+            \`\`\``
+            });
+
+  # Delete Docker image when PR is closed/merged
+  delete-image:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    
+    steps:
+      - name: Lowercase repository name
+        id: repo-name
+        run: |
+          echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "REPO=$(echo '${{ github.repository }}' | cut -d '/' -f 2 | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+      
+      - name: Delete Docker image
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = '${{ steps.repo-name.outputs.OWNER }}';
+            const repo = '${{ steps.repo-name.outputs.REPO }}';
+            const package_name = `${repo}/pr-${context.issue.number}`;
+            
+            console.log(`Attempting to delete package: ${package_name}`);
+            
+            try {
+              // For organization repos
+              await github.rest.packages.deletePackageForOrg({
+                package_type: 'container',
+                package_name: package_name,
+                org: owner
+              });
+              console.log('Package deleted successfully via org API');
+            } catch (orgError) {
+              console.log(`Error deleting via org API: ${orgError.message}`);
+              
+              try {
+                // For user repos
+                await github.rest.packages.deletePackageForUser({
+                  package_type: 'container',
+                  package_name: package_name,
+                  username: owner
+                });
+                console.log('Package deleted successfully via user API');
+              } catch (userError) {
+                console.log(`Error deleting via user API: ${userError.message}`);
+              }
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -49,19 +49,43 @@ jobs:
         with:
           script: |
             const imageName = `ghcr.io/${{ steps.repo-name.outputs.REPO_NAME }}/pr-${context.issue.number}:latest`;
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `📦 Docker image for this PR is available at: \`${imageName}\`
+            const commentBody = `📦 Docker image for this PR is available at: \`${imageName}\`
             
             You can pull it with:
             \`\`\`
             docker pull ${imageName}
             docker run ${imageName}
-            \`\`\``
+            \`\`\``;
+
+            // Get all comments on the PR
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
             });
+
+            // Look for an existing Docker image comment
+            const dockerComment = comments.data.find(comment => 
+              comment.body.includes('📦 Docker image for this PR is available at:')
+            );
+
+            if (dockerComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: dockerComment.id,
+                body: commentBody
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody
+              });
+            }
 
   # Delete Docker image when PR is closed/merged
   delete-image:

--- a/cmd_check.go
+++ b/cmd_check.go
@@ -33,35 +33,15 @@ var checkCommand = &cobra.Command{
 			return err
 		}
 
-		var ext extension.Extension
 		var toolCfg *tool.ToolConfig
 
 		if stat.IsDir() {
-			if !tool.IsProject(args[0]) {
-				if err := copyFiles(args[0], tmpDir); err != nil {
-					return err
-				}
-
-				ext, err = extension.GetExtensionByFolder(tmpDir)
-
-				if err != nil {
-					return err
-				}
-
-				toolCfg, err = tool.ConvertExtensionToToolConfig(ext)
-
-				if err != nil {
-					return err
-				}
-			} else {
-				toolCfg, err = tool.GetConfigFromProject(args[0])
-
-				if err != nil {
-					return err
-				}
+			toolCfg, err = getToolConfig(args[0])
+			if err != nil {
+				return err
 			}
 		} else {
-			ext, err = extension.GetExtensionByZip(args[0])
+			ext, err := extension.GetExtensionByZip(args[0])
 
 			if err != nil {
 				return err

--- a/cmd_check.go
+++ b/cmd_check.go
@@ -36,7 +36,11 @@ var checkCommand = &cobra.Command{
 		var toolCfg *tool.ToolConfig
 
 		if stat.IsDir() {
-			toolCfg, err = getToolConfig(args[0])
+			if err := copyFiles(args[0], tmpDir); err != nil {
+				return err
+			}
+
+			toolCfg, err = getToolConfig(tmpDir)
 			if err != nil {
 				return err
 			}

--- a/cmd_fix.go
+++ b/cmd_fix.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/shopware/extension-verifier/internal/tool"
-	"github.com/shopware/shopware-cli/extension"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )

--- a/cmd_fix.go
+++ b/cmd_fix.go
@@ -25,16 +25,24 @@ var (
 				}
 			}
 
-			ext, err := extension.GetExtensionByFolder(args[0])
+			var toolCfg *tool.ToolConfig
+			var err error
 
-			if err != nil {
-				return err
-			}
+			if tool.IsProject(args[0]) {
+				toolCfg, err = tool.GetConfigFromProject(args[0])
+				if err != nil {
+					return err
+				}
+			} else {
+				ext, err := extension.GetExtensionByFolder(args[0])
+				if err != nil {
+					return err
+				}
 
-			toolCfg, err := tool.ConvertExtensionToToolConfig(ext)
-
-			if err != nil {
-				return err
+				toolCfg, err = tool.ConvertExtensionToToolConfig(ext)
+				if err != nil {
+					return err
+				}
 			}
 
 			var gr errgroup.Group

--- a/cmd_fix.go
+++ b/cmd_fix.go
@@ -25,24 +25,9 @@ var (
 				}
 			}
 
-			var toolCfg *tool.ToolConfig
-			var err error
-
-			if tool.IsProject(args[0]) {
-				toolCfg, err = tool.GetConfigFromProject(args[0])
-				if err != nil {
-					return err
-				}
-			} else {
-				ext, err := extension.GetExtensionByFolder(args[0])
-				if err != nil {
-					return err
-				}
-
-				toolCfg, err = tool.ConvertExtensionToToolConfig(ext)
-				if err != nil {
-					return err
-				}
+			toolCfg, err := getToolConfig(args[0])
+			if err != nil {
+				return err
 			}
 
 			var gr errgroup.Group

--- a/cmd_format.go
+++ b/cmd_format.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/shopware/extension-verifier/internal/tool"
-	"github.com/shopware/shopware-cli/extension"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -12,19 +11,12 @@ var formatCommand = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Short: "Formats the Shopware extension",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ext, err := extension.GetExtensionByFolder(args[0])
-
+		toolCfg, err := getToolConfig(args[0])
 		if err != nil {
 			return err
 		}
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
-
-		toolCfg, err := tool.ConvertExtensionToToolConfig(ext)
-
-		if err != nil {
-			return err
-		}
 
 		var gr errgroup.Group
 

--- a/cmd_shared.go
+++ b/cmd_shared.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/shopware/extension-verifier/internal/tool"
+	"github.com/shopware/shopware-cli/extension"
 )
 
 func filterTools(tools []tool.Tool, only string) ([]tool.Tool, error) {

--- a/cmd_shared.go
+++ b/cmd_shared.go
@@ -34,3 +34,27 @@ func filterTools(tools []tool.Tool, only string) ([]tool.Tool, error) {
 
 	return filteredTools, nil
 }
+
+func getToolConfig(path string) (*tool.ToolConfig, error) {
+	var toolCfg *tool.ToolConfig
+	var err error
+
+	if tool.IsProject(path) {
+		toolCfg, err = tool.GetConfigFromProject(path)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ext, err := extension.GetExtensionByFolder(path)
+		if err != nil {
+			return nil, err
+		}
+
+		toolCfg, err = tool.ConvertExtensionToToolConfig(ext)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return toolCfg, nil
+}


### PR DESCRIPTION
Add a check in `cmd_fix.go` to determine if the provided path is a project.

* Use `tool.IsProject` to check if the provided path is a project.
* If the path is a project, retrieve the tool configuration using `tool.GetConfigFromProject`.
* If the path is not a project, retrieve the extension by folder and convert it to a tool configuration using `tool.ConvertExtensionToToolConfig`.
* Update the logic to be consistent with `cmd_check.go` for determining if the provided path is a project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopwareLabs/extension-verifier/pull/42?shareId=8e2e8e86-fef0-4cd0-b94a-e15bea36bd0d).