### PR TITLE
feat: add phpstan-disallowed-calls extension

### DIFF
--- a/internal/tool/phpstan.neon.sw6
+++ b/internal/tool/phpstan.neon.sw6
@@ -1,3 +1,7 @@
+includes:
+    - vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
+    - vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
+
 parameters:
     level: 0
 
@@ -14,3 +18,11 @@ parameters:
 
     reportUnmatchedIgnoredErrors: false
     tipsOfTheDay: false
+    disallowedFunctionCalls:
+        -
+            function: 'dd()'
+            message: 'do not use dd() in production code'
+        -
+            function: 'dump()'
+            message: 'do not use dump() in production code'
+            

--- a/tools/php/composer.json
+++ b/tools/php/composer.json
@@ -7,7 +7,8 @@
         "phpstan/phpstan-symfony": "*",
         "rector/rector": "^2.0",
         "frosh/shopware-rector": "^0.5.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "spaze/phpstan-disallowed-calls": "^4.0"
     },
     "replace": {
         "symfony/polyfill-ctype": "*",

--- a/tools/php/composer.lock
+++ b/tools/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e63da4bba7cb826811778cbeffbfeeb",
+    "content-hash": "0c6a85829172bcae32b920946d0e2dd1",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -1637,6 +1637,73 @@
             "time": "2025-03-12T14:11:05+00:00"
         },
         {
+            "name": "spaze/phpstan-disallowed-calls",
+            "version": "v4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spaze/phpstan-disallowed-calls.git",
+                "reference": "1c5e6996bd75a1460f5e2683fc4294665b37bee2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/1c5e6996bd75a1460f5e2683fc4294665b37bee2",
+                "reference": "1c5e6996bd75a1460f5e2683fc4294665b37bee2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^1.12.6 || ^2.0"
+            },
+            "require-dev": {
+                "nette/neon": "^3.3.1",
+                "nikic/php-parser": "^4.13.2 || ^5.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^1.2 || ^2.0",
+                "phpunit/phpunit": "^8.5.14 || ^10.1 || ^11.0 || ^12.0",
+                "spaze/coding-standard": "^1.8"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spaze\\PHPStan\\Rules\\Disallowed\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michal Špaček",
+                    "email": "mail@michalspacek.cz",
+                    "homepage": "https://www.michalspacek.cz"
+                }
+            ],
+            "description": "PHPStan rules to detect disallowed method & function calls, constant, namespace, attribute & superglobal usages, with powerful rules to re-allow a call or a usage in places where it should be allowed.",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/spaze/phpstan-disallowed-calls/issues",
+                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v4.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spaze",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-10T19:01:43+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v7.2.5",
             "source": {
@@ -2522,10 +2589,10 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Add phpstan-disallowed-calls to detect leftover debug functions like var_dump or dd along with more evil things like eval